### PR TITLE
psf_projected.py should take in original snapshot image to get reference coordinates

### DIFF
--- a/bin/mosaic.tmpl
+++ b/bin/mosaic.tmpl
@@ -166,8 +166,9 @@ if [[ ! -e ${outname}.fits ]] || [[ ! -e ${outname}_psfmap.fits ]]; then
         # keep name the same for easier naming rather than append .resamp
         echo "${resampdir}/${obsnum}_deep-${subchan}-image-pb_warp_rescaled.fits" >> $tmp_resamp
         
-        # create snapshot PSF on resampled image:
-        psf_projected.py ${resampdir}/${obsnum}_deep-${subchan}-image-pb_warp_rescaled.fits
+        # create snapshot PSF on resampled image: 
+        # psf_projected.py new_image old_image
+        psf_projected.py ${resampdir}/${obsnum}_deep-${subchan}-image-pb_warp.fits ../${obsnum}/${obsnum}_deep-${subchan}-image-pb_warp.fits 
         echo "${resampdir}/${obsnum}_deep-${subchan}-image-pb_warp_rescaled_bmaj.fits" >> $tmp_bmaj
         echo "${resampdir}/${obsnum}_deep-${subchan}-image-pb_warp_rescaled_bmin.fits" >> $tmp_bmin
         echo "${resampdir}/${obsnum}_deep-${subchan}-image-pb_warp_rescaled_bpa.fits" >> $tmp_bpa

--- a/bin/psf_projected.py
+++ b/bin/psf_projected.py
@@ -160,6 +160,7 @@ def make_effective_psf(dOmega_map, outname, bmaj, bmin=None, bpa=0.):
 
     shape = hdu[0].data.shape
 
+
     psf = {}
     #  Swarp cannot cope with cubes, so we have to output each aspect of the PSF individually
     psf["bmaj"] = bmaj / hdu[0].data
@@ -204,7 +205,7 @@ def main():
 
     original_projection = "SIN"
     with fits.open(args.original_image) as f:
-        ra0 = f[0].header["CRVAl1"]
+        ra0 = f[0].header["CRVAL1"]
         dec0 = f[0].header["CRVAL2"]
 
     outname = args.new_image.replace(".fits", "")

--- a/bin/psf_projected.py
+++ b/bin/psf_projected.py
@@ -182,8 +182,10 @@ def main():
                                     "varies over the new map.",
                         )
 
+    ps.add_argument("new_image", tye=str,
+                    help="New (resampled/reprojected) FITS image in ZEA projection.")
     ps.add_argument("original_image", type=str,
-                    help="Original FITS image in SIN or ZEA projection. Used to get "
+                    help="Original FITS image in SIN projection. Used to get "
                          "original CRVAL1/CRVAL2 values.")
 
 
@@ -200,13 +202,13 @@ def main():
     except KeyError:
         bpa = 0.
 
+    original_projection = "SIN"
     with fits.open(args.original_image) as f:
-        original_projection = check_projection(f[0].header)
-        ra = f[0].header["CRVAL1"]
-        dec = f[0].header["CRVAL2"] 
+        ra0 = f[0].header["CRVAl1"]
+        dec0 = f[0].header["CRVAL2"]
 
-    outname = args.original_image.replace(".fits", "")
-    hdu = make_ratio_map(args.original_image, ra, dec, outname=None)
+    outname = args.new_image.replace(".fits", "")
+    hdu = make_ratio_map(args.new_image, ra0, dec0, outname=None)
     make_effective_psf(hdu, outname, bmaj, bmin, bpa)
 
 


### PR DESCRIPTION
psf_projected.py should take in original snapshot image to get reference coordinates, which is then used to create the projected PSF factors on the resampled/re-projected image. 