### PR TITLE
removed instances of $USER of $SLURM_JOB_USER

### DIFF
--- a/bin/apply_cal.tmpl
+++ b/bin/apply_cal.tmpl
@@ -6,7 +6,9 @@
 #SBATCH --time=06:00:00
 #SBATCH --nodes=1
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 function test_fail {
 if [[ $1 != 0 ]]

--- a/bin/arr_beams.sh
+++ b/bin/arr_beams.sh
@@ -11,6 +11,8 @@ echo "arr_beams.sh [-d dep] [-q queue] [-b beamlist] [-c] [-t] obsnum
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "gala" ]]
 then
@@ -41,8 +43,8 @@ then
 fi
 
 #initial variables
-base="$scratch/mwasci/$USER/GLEAMX/"
-code="$group/mwasci/$USER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/GLEAMX/"
+code="$group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 queue="-p $standardq"
 beamlist=
 dep=

--- a/bin/autocal.tmpl
+++ b/bin/autocal.tmpl
@@ -7,7 +7,8 @@
 #SBATCH --nodes=1
 TASKLINE
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 function test_fail {
 if [[ $1 != 0 ]]
@@ -24,7 +25,7 @@ modeldir="/group/mwasci/code/anoko/mwa-reduce/models"
 refant=127
 
 # GLEAM-X sky model
-catfile="/group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/models/skymodel_only_alpha.fits"
+catfile="/group/mwasci/$pipeuser/GLEAM-X-pipeline/models/skymodel_only_alpha.fits"
 
 # MWA beam information
 MWAPATH=/group/mwasci/software/mwa_pb/mwa_pb/data/
@@ -62,8 +63,8 @@ then
 
     if [[ ! -e "${obsnum}_local_gleam_model.txt" ]]
     then
-        /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/crop_catalogue.py --ra=$RA --dec=$Dec --radius=30 --minflux=1.0 --metafits=${metafits} --catalogue=${catfile} --fluxcol=S_200 --plot ${obsnum}_local_gleam_model.png --output ${obsnum}_cropped_catalogue.fits
-        /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/vo2model.py --catalogue=${obsnum}_cropped_catalogue.fits --point --output=${obsnum}_local_gleam_model.txt --racol=RAJ2000 --decol=DEJ2000 --acol=a --bcol=b --pacol=pa --fluxcol=S_200 --alphacol=alpha
+        /group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/crop_catalogue.py --ra=$RA --dec=$Dec --radius=30 --minflux=1.0 --metafits=${metafits} --catalogue=${catfile} --fluxcol=S_200 --plot ${obsnum}_local_gleam_model.png --output ${obsnum}_cropped_catalogue.fits
+        /group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/vo2model.py --catalogue=${obsnum}_cropped_catalogue.fits --point --output=${obsnum}_local_gleam_model.txt --racol=RAJ2000 --decol=DEJ2000 --acol=a --bcol=b --pacol=pa --fluxcol=S_200 --alphacol=alpha
     fi
     modeldir=.
     calmodel=${obsnum}_local_gleam_model.txt
@@ -92,7 +93,7 @@ current=`chgcentre ${obsnum}.ms`
 if [[ $current == *"shift"* ]]
 then
     echo "Detected that this measurement set has undergone a denormal shift; this must be undone before calibration."
-    coords=`python /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/calc_pointing.py --metafits=${metafits}`
+    coords=`python /group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/calc_pointing.py --metafits=${metafits}`
     echo "Optimally shifting co-ordinates of measurement set to $coords, without zenith shiftback."
     chgcentre ${obsnum}.ms $coords
 else
@@ -130,7 +131,7 @@ calibrate -j ${cores} -m ${modeldir}/${calmodel} -minuv $minuvm -maxuv $maxuvm -
 test_fail $?
 
 # Create a version divided through by the reference antenna, so that all observations have the same relative XY phase, allowing polarisation calibration solutions to be transferred
-/group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/aocal_phaseref.py ${solutions} ${solutions%.bin}_ref.bin ${refant}
+/group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/aocal_phaseref.py ${solutions} ${solutions%.bin}_ref.bin ${refant}
 
 # plot calibration solutions
 aocal_plot.py --refant=${refant} --amp_max=2 ${solutions%.bin}_ref.bin

--- a/bin/autoflag.tmpl
+++ b/bin/autoflag.tmpl
@@ -7,7 +7,8 @@
 #SBATCH --nodes=1
 TASKLINE
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 function test_fail {
 if [[ $1 != 0 ]]

--- a/bin/calibrate.tmpl
+++ b/bin/calibrate.tmpl
@@ -6,7 +6,9 @@
 #SBATCH --time=12:00:00
 #SBATCH --nodes=1
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 function test_fail {
 if [[ $1 != 0 ]]

--- a/bin/checksrcs.tmpl
+++ b/bin/checksrcs.tmpl
@@ -6,6 +6,7 @@
 #SBATCH --time=06:00:00
 #SBATCH --nodes=1
 
+pipeuser=PIPEUSER
 
 function test_fail {
 if [[ $1 != 0 ]]

--- a/bin/cotter.tmpl
+++ b/bin/cotter.tmpl
@@ -7,7 +7,9 @@
 #SBATCH --nodes=1
 TASKLINE
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 function test_fail {
 if [[ $1 != 0 ]]

--- a/bin/dl.tmpl
+++ b/bin/dl.tmpl
@@ -6,7 +6,9 @@
 #SBATCH --time=02:00:00
 #SBATCH --nodes=1
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 function test_fail {
 if [[ $1 != 0 ]]

--- a/bin/drift_mosaic.sh
+++ b/bin/drift_mosaic.sh
@@ -15,6 +15,8 @@ echo "drift_mosaic.sh [-p project] [-d dep] [-q queue] [-a account] [-t] [-r ra]
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "zeus" ]]
 then
@@ -40,8 +42,8 @@ fi
 
 scratch="/astro"
 group="/group"
-base="$scratch/mwasci/$USER/"
-dbdir="$group/mwasci/$USER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/"
+dbdir="$group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 dep=
 queue="-p $standardq"
 account=
@@ -107,7 +109,8 @@ cat ${dbdir}/bin/mosaic.tmpl | sed -e "s:OBSLIST:${obslist}:g" \
                                  -e "s:ACCOUNT:${account}:g" \
                                  -e "s:RAPOINT:${ra}:g" \
                                  -e "s:DECPOINT:${dec}:g" \
-                                 -e "s:BASEDIR:${base}:g"  > ${script}
+                                 -e "s:BASEDIR:${base}:g" \
+                                 -e "s:PIPEUSER:${pipeuser}:g" > ${script}
 
 output="${dbdir}queue/logs/mosaic_${listbase}.o%A_%a"
 error="${dbdir}queue/logs/mosaic_${listbase}.e%A_%a"

--- a/bin/drift_rescale.sh
+++ b/bin/drift_rescale.sh
@@ -14,6 +14,8 @@ echo "drift_rescale.sh [-p project] [-d dep] [-q queue] [-a account] [-t] [-r] [
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "zeus" ]]
 then
@@ -39,8 +41,8 @@ fi
 
 scratch="/astro"
 group="/group"
-base="$scratch/mwasci/$USER/"
-dbdir="$group/mwasci/$USER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/"
+dbdir="$group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 dep=
 queue="-p $standardq"
 account=
@@ -102,7 +104,8 @@ script="${dbdir}queue/rescale_${listbase}.sh"
 cat ${dbdir}/bin/rescale.tmpl | sed -e "s:OBSLIST:${obslist}:g" \
                                  -e "s:ACCOUNT:${account}:g" \
                                  -e "s:READ:${readfile}:g" \
-                                 -e "s:BASEDIR:${base}:g"  > ${script}
+                                 -e "s:BASEDIR:${base}:g"  \
+                                 -e "s:PIPEUSER:${pipeuser}:g" > ${script}
 
 output="${dbdir}queue/logs/rescale_${listbase}.o%A_%a"
 error="${dbdir}queue/logs/rescale_${listbase}.e%A_%a"

--- a/bin/flagsubs.tmpl
+++ b/bin/flagsubs.tmpl
@@ -6,7 +6,9 @@
 #SBATCH --time=01:00:00
 #SBATCH --nodes=1
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 function test_fail {
 if [[ $1 != 0 ]]

--- a/bin/image.tmpl
+++ b/bin/image.tmpl
@@ -7,7 +7,9 @@
 #SBATCH --ntasks=NCPUS
 #SBATCH --nodes=1
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 function test_fail {
 if [[ $1 != 0 ]]
@@ -102,7 +104,7 @@ then
     echo "Detected that this measurement set has already had its phase centre changed. Not shifting."
 else
     # Determine whether to shift the pointing centre to be more optimally-centred on the peak of the primary beam sensitivity
-    coords=`python /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/calc_pointing.py --metafits=${metafits}`
+    coords=`python /group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/calc_pointing.py --metafits=${metafits}`
     echo "Optimally shifting co-ordinates of measurement set to $coords, with zenith shiftback."
     chgcentre ${obsnum}.ms $coords
     # Now shift the pointing centre to point straight up, which approximates minw without making the phase centre rattle around

--- a/bin/manta.tmpl
+++ b/bin/manta.tmpl
@@ -6,7 +6,9 @@
 #SBATCH --time=12:00:00
 #SBATCH --nodes=1
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 alias mwa_client='module load singularity; env PYTHONPATH= singularity exec /pawsey/mwa/singularity/manta-ray-client/manta-ray-client_latest.sif mwa_client $@'
 
 base=BASEDIR

--- a/bin/mosaic.tmpl
+++ b/bin/mosaic.tmpl
@@ -6,7 +6,7 @@
 #SBATCH --array=0-4
 
 pipeuser=PIPEUSER
-
+export pipeuser
 source /group/mwasci/$pieuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 set -x

--- a/bin/mosaic.tmpl
+++ b/bin/mosaic.tmpl
@@ -5,7 +5,9 @@
 #SBATCH --nodes=1
 #SBATCH --array=0-4
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pieuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 set -x
 
@@ -131,7 +133,7 @@ cd mosaics/
 #raend=`pyhead.py -p CRVAL1 $last`
 
 # Create a swarp template file for resampling
-cat /group/mwasci/${SLURM_JOB_USER}/GLEAM-X-pipeline/mosaics/resamp.swarp.tmpl \
+cat /group/mwasci/${pipeuser}/GLEAM-X-pipeline/mosaics/resamp.swarp.tmpl \
     | sed "s;OUTIMAGE;${imageout}.fits;" \
     | sed "s;OUTWEIGHT;${weightout};" \
     | sed "s;WEIGHT_NAMES;${imagelist}.weights.list;" \
@@ -238,8 +240,8 @@ if [[ ! -e ${outname}_ddmod.fits ]] || [[ ! -e ${outname}_psf.fits ]]; then
     # Generate a measured PSF map
     if [[ ! -e ${outname}_psf.fits ]]
     then
-        /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/psf_select.py --input=${outname}_comp.fits
-        /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/psf_create.py --input=${outname}_comp_psfcat.fits
+        /group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/psf_select.py --input=${outname}_comp.fits
+        /group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/psf_create.py --input=${outname}_comp_psfcat.fits
     fi
 
     # Run source-finding using the mosaicked PSF map as an input
@@ -251,15 +253,15 @@ if [[ ! -e ${outname}_ddmod.fits ]] || [[ ! -e ${outname}_psf.fits ]]; then
     # Select sources and generate a new PSF map that has the right blur factor
     if [[ ! -e ${outname}_projpsf_psf.fits ]]
     then
-        /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/psf_select.py --input=${outname}_projpsf_comp.fits
-        /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/psf_create.py --input=${outname}_projpsf_comp_psfcat.fits
+        /group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/psf_select.py --input=${outname}_projpsf_comp.fits
+        /group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/psf_create.py --input=${outname}_projpsf_comp_psfcat.fits
     fi
 
     # Multiply by blur factor
     if [[ ! -e ${outname}_ddmod.fits ]]
     then
         # TODO parallelise this code
-        /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/dd_flux_mod.py --mosaic=${outname}.fits --psf=${outname}_projpsf_psf.fits --output=${outname}_ddmod.fits
+        /group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/dd_flux_mod.py --mosaic=${outname}.fits --psf=${outname}_projpsf_psf.fits --output=${outname}_ddmod.fits
     fi
 
     # Rerun source-finding on blur-corrected map with measured PSF map

--- a/bin/obs_apply_cal.sh
+++ b/bin/obs_apply_cal.sh
@@ -17,6 +17,8 @@ echo "obs_apply_cal.sh [-p project] [-d dep] [-a account] [-c calid] [-z] [-t] o
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "zeus" ]]
 then
@@ -97,8 +99,8 @@ fi
 
 # Set directories
 queue="-p $standardq"
-dbdir="/group/mwasci/$USER/GLEAM-X-pipeline/"
-base="$scratch/mwasci/$USER/$project/"
+dbdir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/$project/"
 
 if [[ $? != 0 ]]
 then
@@ -118,7 +120,8 @@ cat apply_cal.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                      -e "s:STANDARDQ:${standardq}:g" \
                                      -e "s:ACCOUNT:${account}:g" \
                                      -e "s:DEBUG:${debug}:g" \
-                                     -e "s:CALID:${calid}:g"  > ${script}
+                                     -e "s:CALID:${calid}:g" \
+                                     -e "s:PIPEUSER:${pipeuser}:g" > ${script}
 
 output="${dbdir}queue/logs/apply_cal_${obsnum}.o%A"
 error="${dbdir}queue/logs/apply_cal_${obsnum}.e%A"

--- a/bin/obs_autocal.sh
+++ b/bin/obs_autocal.sh
@@ -15,6 +15,8 @@ echo "obs_autocal.sh [-d dep] [-a account] [-t] obsnum
 exit 1;
 }
 
+pipeline=$(whoami)
+
 dep=
 tst=
 ion=
@@ -83,10 +85,10 @@ then
 #    absmem=30 # Check this
 fi
 
-dbdir="/group/mwasci/$USER/GLEAM-X-pipeline/"
-codedir="/group/mwasci/$USER/GLEAM-X-pipeline/"
+dbdir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
+codedir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 queue="-p $standardq"
-datadir=/astro/mwasci/$USER/$project
+datadir=/astro/mwasci/$pipeuser/$project
 
 # set dependency
 if [[ ! -z ${dep} ]]
@@ -103,7 +105,8 @@ cat ${codedir}bin/autocal.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                      -e "s:TASKLINE:${taskline}:g" \
                                      -e "s:STANDARDQ:${standardq}:g" \
                                      -e "s:IONOTEST:${ion}:g" \
-                                     -e "s:ACCOUNT:${account}:g" > ${script}
+                                     -e "s:ACCOUNT:${account}:g" \
+                                     -e "s:PIPEUSER:${pipeuser}:g" > ${script}
 
 output="${codedir}queue/logs/autocal_${obsnum}.o%A"
 error="${codedir}queue/logs/autocal_${obsnum}.e%A"

--- a/bin/obs_autoflag.sh
+++ b/bin/obs_autoflag.sh
@@ -14,6 +14,8 @@ echo "obs_autoflag.sh [-p project] [-a account] [-d dep] [-t] obsnum
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 dep=
 tst=
 
@@ -78,10 +80,10 @@ then
 #    absmem=30 # Check this
 fi
 
-dbdir="/group/mwasci/$USER/GLEAM-X-pipeline/"
-codedir="/group/mwasci/$USER/GLEAM-X-pipeline/"
+dbdir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
+codedir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 queue="-p $standardq"
-datadir=/astro/mwasci/$USER/$project
+datadir=/astro/mwasci/$pipeuser/$project
 
 # set dependency
 if [[ ! -z ${dep} ]]
@@ -96,7 +98,8 @@ cat ${codedir}bin/autoflag.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                      -e "s:HOST:${computer}:g" \
                                      -e "s:TASKLINE:${taskline}:g" \
                                      -e "s:STANDARDQ:${standardq}:g" \
-                                     -e "s:ACCOUNT:${account}:g" > ${script}
+                                     -e "s:ACCOUNT:${account}:g" \
+                                     -e "s:PIPEUSER:${pipeuser}:g"> ${script}
 
 output="${codedir}queue/logs/autoflag_${obsnum}.o%A"
 error="${codedir}queue/logs/autoflag_${obsnum}.e%A"

--- a/bin/obs_calibrate.sh
+++ b/bin/obs_calibrate.sh
@@ -13,6 +13,8 @@ echo "obs_calibrate.sh [-d dep] [-q queue] [-n calname] [-t] obsnum
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "gala" ]]
 then
@@ -38,7 +40,7 @@ fi
 
 #initialize as empty
 scratch=/astro
-base="$scratch/mwasci/$USER/GLEAMX/"
+base="$scratch/mwasci/$pipeuser/GLEAMX/"
 dep=
 queue='-p workq'
 calname=
@@ -89,7 +91,8 @@ cat ${base}/bin/calibrate.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                      -e "s:CALIBRATOR:${calname}:g" \
                                      -e "s:HOST:${computer}:g" \
                                      -e "s:STANDARDQ:${standardq}:g" \
-                                     -e "s:ACCOUNT:${account}:g" > ${script}
+                                     -e "s:ACCOUNT:${account}:g" \
+                                     -e "s:PIPEUSER:${pipeuser}:g" > ${script}
 
 output="${base}queue/logs/calibrate_${obsnum}.o%A"
 error="${base}queue/logs/calibrate_${obsnum}.e%A"

--- a/bin/obs_checksrcs.sh
+++ b/bin/obs_checksrcs.sh
@@ -11,6 +11,8 @@ echo "obs_checksrcs.sh [-d dep] [-q queue] [-n calname] [-t] obsnum
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "gala" ]]
 then
@@ -36,7 +38,7 @@ fi
 
 #initialize as empty
 scratch=/astro
-base="$scratch/mwasci/$USER/GLEAMX/"
+base="$scratch/mwasci/$pipeuser/GLEAMX/"
 dep=
 queue='-p $standardq'
 tst=
@@ -88,7 +90,8 @@ cat ${base}/bin/checksrcs.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                      -e "s:SRCLIST:${srclist}:g" \
                                      -e "s:HOST:${computer}:g" \
                                      -e "s:STANDARDQ:${standardq}:g" \
-                                     -e "s:ACCOUNT:${account}:g" > ${script}
+                                     -e "s:ACCOUNT:${account}:g" \
+                                     -e "s:PIPEUSER:${pipeuser}:g"> ${script}
 
 output="${base}queue/logs/checksrcs_${obsnum}.o%A"
 error="${base}queue/logs/checksrcs_${obsnum}.e%A"

--- a/bin/obs_cotter.sh
+++ b/bin/obs_cotter.sh
@@ -14,6 +14,8 @@ echo "obs_cotter.sh [-p project] [-d dep] [-a account] [-t] obsnum
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "zeus" ]]
 then
@@ -83,9 +85,9 @@ then
 fi
 
 queue="-p $standardq"
-dbdir="/group/mwasci/$USER/GLEAM-X-pipeline/"
-codedir="/group/mwasci/$USER/GLEAM-X-pipeline/"
-datadir=/astro/mwasci/$USER/$project
+dbdir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
+codedir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
+datadir=/astro/mwasci/$pipeuser/$project
 
 if [[ $obsnum -lt 1151402936 ]] ; then
     telescope="MWA128T"
@@ -113,7 +115,8 @@ cat ${codedir}bin/cotter.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                   -e "s:MEMORY:${memory}:g" \
                                   -e "s:HOST:${computer}:g" \
                                   -e "s:STANDARDQ:${standardq}:g" \
-                                  -e "s:ACCOUNT:${account}:g" > ${script}
+                                  -e "s:ACCOUNT:${account}:g" \
+                                  -e "s:PIPEUSER:${pipeuser}:g" > ${script}
 
 output="${codedir}queue/logs/cotter_${obsnum}.o%A"
 error="${codedir}queue/logs/cotter_${obsnum}.e%A"

--- a/bin/obs_idg.sh
+++ b/bin/obs_idg.sh
@@ -14,6 +14,8 @@ echo "obs_idg.sh [-p project] [-d dep] [-q queue] [-s] [-t] -o list_of_observati
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "zeus" ]]
 then
@@ -38,8 +40,8 @@ fi
 
 scratch="/astro"
 group="/group"
-base="$scratch/mwasci/$USER/"
-dbdir="$group/mwasci/$USER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/"
+dbdir="$group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 dep=
 queue="-p $standardq"
 tst=false

--- a/bin/obs_image.sh
+++ b/bin/obs_image.sh
@@ -14,6 +14,8 @@ echo "obs_image.sh [-d dep] [-p project] [-a account] [-z] [-t] obsnum
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "zeus" ]]
 then
@@ -71,8 +73,8 @@ shift  "$(($OPTIND -1))"
 obsnum=$1
 
 queue="-p $standardq"
-base="$scratch/mwasci/$USER/$project/"
-code="$group/mwasci/$USER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/$project/"
+code="$group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 
 # if obsid is empty then just print help
 
@@ -100,7 +102,8 @@ cat ${code}/bin/image.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                  -e "s:HOST:${computer}:g" \
                                  -e "s:STANDARDQ:${standardq}:g" \
                                  -e "s:DEBUG:${debug}:g" \
-                                 -e "s:ACCOUNT:${account}:g" > ${script}
+                                 -e "s:ACCOUNT:${account}:g" \
+                                 -e "s:PIPEUSER:${pipeuser}:g"> ${script}
 
 output="${code}queue/logs/image_${obsnum}.o%A"
 error="${code}queue/logs/image_${obsnum}.e%A"

--- a/bin/obs_manta.sh
+++ b/bin/obs_manta.sh
@@ -21,12 +21,14 @@ computer="zeus"
 account="mwasci"
 standardq="copyq"
 
+PIPEUSER=$(whoami)
+
 #initial variables
 
 scratch="/astro"
 group="/group"
-base="$scratch/mwasci/$USER/"
-dbdir="$group/mwasci/$USER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$PIPEUSER/"
+dbdir="$group/mwasci/$PIPEUSER/GLEAM-X-pipeline/"
 dep=
 queue="-p $standardq"
 tst=

--- a/bin/obs_postimage.sh
+++ b/bin/obs_postimage.sh
@@ -12,6 +12,8 @@ echo "obs_postimage.sh [-d dep] [-p project] [-a account] [-t] obsnum
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "zeus" ]]
 then
@@ -69,8 +71,8 @@ shift  "$(($OPTIND -1))"
 obsnum=$1
 
 queue="-p $standardq"
-base="$scratch/mwasci/$USER/$project/"
-code="$group/mwasci/$USER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/$project/"
+code="$group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 
 # if obsid is empty then just print help
 

--- a/bin/obs_rfifind.sh
+++ b/bin/obs_rfifind.sh
@@ -10,6 +10,9 @@ echo "obs_rfifind.sh [-d dep] [-p project] [-q queue] [-t] obsnum
   obsnum     : the obsid to process" 1>&2;
 exit 1;
 }
+
+pipeuser=$(whoami)
+
 # No options for queue - has to be run on gpuq
 #  -q queue   : job queue, default=workq
 # Supercomputer options
@@ -67,8 +70,8 @@ done
 shift  "$(($OPTIND -1))"
 obsnum=$1
 
-base="$scratch/mwasci/$USER/$project/"
-code="$group/mwasci/$USER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/$project/"
+code="$group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 
 # if obsid is empty then just print help
 
@@ -96,7 +99,8 @@ cat ${code}/bin/radiance.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                  -e "s:STANDARDQ:gpuq:g" \
                                  -e "s:ACCOUNT:${account}:g" \
                                  -e "s:OUTPUT:${output}:g"\
-                                 -e "s:ERROR:${error}:g" > ${script}
+                                 -e "s:ERROR:${error}:g" \
+                                 -e "s:PIPELINE:${pipeline}:g"> ${script}
 
 dep=($(sbatch -M zeus --begin=now+15 --output=${output} --error=${error} ${depend} ${queue} ${script}))
 depend=${dep[3]}
@@ -128,7 +132,8 @@ cat ${code}/bin/rfifind.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                  -e "s:STANDARDQ:workq:g" \
                                  -e "s:ACCOUNT:${account}:g" \
                                  -e "s:OUTPUT:${output}:g"\
-                                 -e "s:ERROR:${error}:g" > ${script}
+                                 -e "s:ERROR:${error}:g" \
+                                 -e "s:PIPEUSER:${pipeuser}:g"> ${script}
 
 dep=($(sbatch -M zeus --begin=now+15 --output=${output} --error=${error} --dependency=afterok:${depend} ${queue} ${script}))
 depend=${dep[3]}
@@ -150,7 +155,8 @@ cat ${code}/bin/radiance.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                  -e "s:STANDARDQ:gpuq:g" \
                                  -e "s:ACCOUNT:${account}:g" \
                                  -e "s:OUTPUT:${output}:g"\
-                                 -e "s:ERROR:${error}:g" > ${script}
+                                 -e "s:ERROR:${error}:g" \
+                                 -e "s:PIPEUSER:${pipeuser}:g"> ${script}
 
 dep=($(sbatch -M zeus --begin=now+15 --output=${output} --error=${error} --dependency=afterok:${depend} ${queue} ${script}))
 depend=${dep[3]}
@@ -171,7 +177,8 @@ cat ${code}/bin/flagsubs.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                  -e "s:STANDARDQ:workq:g" \
                                  -e "s:ACCOUNT:${account}:g" \
                                  -e "s:OUTPUT:${output}:g"\
-                                 -e "s:ERROR:${error}:g" > ${script}
+                                 -e "s:ERROR:${error}:g" \
+                                 -e "s:PIPEUSER:${pipeuser}:g"> ${script}
 
 dep=($(sbatch -M zeus --begin=now+15 --output=${output} --error=${error} --dependency=afterok:${depend} ${queue} ${script}))
 depend=${dep[3]}

--- a/bin/obs_self.sh
+++ b/bin/obs_self.sh
@@ -12,6 +12,8 @@ echo "obs_self.sh [-p project] [-d dep] [-a account] [-t] obsnum
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "zeus" ]]
 then
@@ -86,10 +88,10 @@ then
 fi
 
 # Set directories
-dbdir="/group/mwasci/$USER/GLEAM-X-pipeline/"
-codedir="/group/mwasci/$USER/GLEAM-X-pipeline/"
+dbdir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
+codedir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 queue="-p $standardq"
-datadir=/astro/mwasci/$USER/$project
+datadir=/astro/mwasci/$pipeuser/$project
 
 # start the real program
 script="${dbdir}queue/self_${obsnum}.sh"
@@ -100,7 +102,8 @@ cat ${dbdir}/bin/self.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                  -e "s:TASKLINE:${taskline}:g" \
                                  -e "s:HOST:${computer}:g" \
                                  -e "s:STANDARDQ:${standardq}:g" \
-                                 -e "s:ACCOUNT:${account}:g" > ${script}
+                                 -e "s:ACCOUNT:${account}:g" \
+                                 -e "s:PIPEUSER:${pipeuser}:g" > ${script}
 
 output="${dbdir}queue/logs/self_${obsnum}.o%A"
 error="${dbdir}queue/logs/self_${obsnum}.e%A"

--- a/bin/obs_testimage.sh
+++ b/bin/obs_testimage.sh
@@ -12,6 +12,8 @@ echo "obs_testimage.sh [-d dep] [-p project] [-q queue] [-t] obsnum
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 # Supercomputer options
 if [[ "${HOST:0:4}" == "zeus" ]]
 then
@@ -71,8 +73,8 @@ done
 shift  "$(($OPTIND -1))"
 obsnum=$1
 
-base="$scratch/mwasci/$USER/$project/"
-code="$group/mwasci/$USER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/$project/"
+code="$group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 
 # if obsid is empty then just print help
 

--- a/bin/obs_uvflag.sh
+++ b/bin/obs_uvflag.sh
@@ -16,6 +16,9 @@ echo "obs_uvflag.sh [-p project] [-d dep] [-a account] [-z] [-t] obsnum
 exit 1;
 }
 
+
+pipeuser=$(whoami)
+
 dep=
 tst=
 debug=
@@ -84,10 +87,10 @@ then
 #    absmem=30 # Check this
 fi
 
-dbdir="/group/mwasci/$USER/GLEAM-X-pipeline/"
-codedir="/group/mwasci/$USER/GLEAM-X-pipeline/"
+dbdir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
+codedir="/group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 queue="-p $standardq"
-datadir=/astro/mwasci/$USER/$project
+datadir=/astro/mwasci/$pipeuser/$project
 
 # set dependency
 if [[ ! -z ${dep} ]]
@@ -104,7 +107,8 @@ cat ${codedir}bin/uvflag.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \
                                      -e "s:TASKLINE:${taskline}:g" \
                                      -e "s:STANDARDQ:${standardq}:g" \
                                      -e "s:DEBUG:${debug}:g" \
-                                     -e "s:ACCOUNT:${account}:g" > ${script}
+                                     -e "s:ACCOUNT:${account}:g" \
+                                     -e "s:PIPEUSER:${pipeuser}:g"> ${script}
 
 output="${codedir}queue/logs/uvflag_${obsnum}.o%A"
 error="${codedir}queue/logs/uvflag_${obsnum}.e%A"

--- a/bin/postimage.tmpl
+++ b/bin/postimage.tmpl
@@ -7,6 +7,9 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=NCPUS
 
+pipeuser=PIPEUSER
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+
 # Makes fits_warp parallelisation work on Zeus
 KMP_INIT_AT_FORK=false
 # Sub-channels
@@ -14,7 +17,7 @@ subchans="0000 0001 0002 0003 MFS"
 # flux_warp method
 method=scaled
 # Sky model
-MODEL_CATALOGUE="/group/mwasci/${SLURM_JOB_USER}/GLEAM-X-pipeline/models/skymodel_only_alpha_sparse_unresolved.fits"
+MODEL_CATALOGUE="/group/mwasci/${pipeuser}/GLEAM-X-pipeline/models/skymodel_only_alpha_sparse_unresolved.fits"
 # Set max separation for flux_warp crossmatch as ~ 1' -- unlikely that the ionosphere would be that brutal
 separation=$(echo "60/3600" | bc -l)
 # Set exclusion for flux_warp internal exclusive crossmatch as ~ 3'
@@ -143,7 +146,7 @@ do
             cstart=${chans[$i]}
             cend=${chans[$j]}
             python /group/mwasci/nhurleywalker/mwa_pb_lookup/lookup_beam.py ${obsnum} _deep-${subchan}-image-pb_warp.fits ${obsnum}_deep-${subchan}-image-pb_warp- -c $cstart-$cend --beam_path /group/mwasci/pb_lookup/gleam_xx_yy.hdf5
-            python /group/mwasci/${SLURM_JOB_USER}/GLEAM-X-pipeline/bin/generate_weight_map.py ${obsnum}_deep-${subchan}-image-pb_warp-XX-beam.fits ${obsnum}_deep-${subchan}-image-pb_warp-YY-beam.fits ${obsnum}_deep-${subchan}-image-pb_warp_rms.fits
+            python /group/mwasci/${pipeuser}/GLEAM-X-pipeline/bin/generate_weight_map.py ${obsnum}_deep-${subchan}-image-pb_warp-XX-beam.fits ${obsnum}_deep-${subchan}-image-pb_warp-YY-beam.fits ${obsnum}_deep-${subchan}-image-pb_warp_rms.fits
         fi
     fi
 done

--- a/bin/prep_IDG.tmpl
+++ b/bin/prep_IDG.tmpl
@@ -8,7 +8,8 @@
 ARRAYLINE
 TASKLINE
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 set -ux
 
@@ -74,7 +75,7 @@ chan=`pyhead.py -p CENTCHAN ${metafits} | awk '{print $3}'`
 # Pixel scale
 scale=`echo "$basescale / $chan" | bc -l` # At least 4 pix per synth beam for each channel
 
-MODEL_CATALOGUE="/group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/models/skymodel_only_alpha.fits"
+MODEL_CATALOGUE="/group/mwasci/$pipeuser/GLEAM-X-pipeline/models/skymodel_only_alpha.fits"
 
 # All observations must be phased to the same point, otherwise IDG will give nonsense results
 # We will use the middle observation of the (already-sorted) list to define the phase centre

--- a/bin/process.sh
+++ b/bin/process.sh
@@ -11,6 +11,8 @@ echo "process.sh [-p project] [-a account] obsnum
 exit 1;
 }
 
+pipeuser=$(whoami)
+
 scratch="/astro"
 group="/group"
 
@@ -43,8 +45,8 @@ then
     account=pawsey0272
 fi
 
-base="$scratch/mwasci/$USER/$project/"
-code="$group/mwasci/$USER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/$project/"
+code="$group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 script="${code}queue/process_${obsnum}.sh"
 
 cat ${code}/bin/chain.tmpl | sed -e "s:OBSNUM:${obsnum}:g" \

--- a/bin/psf_select.py
+++ b/bin/psf_select.py
@@ -33,9 +33,9 @@ def main():
                         help="Output psf FITS file -- default is input_psfcat.fits")
     # allow manual specification of NVSS/SUMSS catalogue (e.g. if running locally...)
     parser.add_argument("--nscat", dest="nscat", type=str,
-                        default="/group/mwasci/$USER/GLEAM-X-pipeline/models/NVSS_SUMSS_psfcal.fits",
+                        default="/group/mwasci/$PIPEUSER/GLEAM-X-pipeline/models/NVSS_SUMSS_psfcal.fits",
                         help="NVSS-SUMSS catalogue filtering extended sources. Default is located at " \
-                             "'/group/mwasci/$USER/GLEAM-X-pipeline/models/NVSS_SUMSS_psfcal.fits'")
+                             "'/group/mwasci/$PIPEUSER/GLEAM-X-pipeline/models/NVSS_SUMSS_psfcal.fits'")
 
     options = parser.parse_args()
 

--- a/bin/psf_select.py
+++ b/bin/psf_select.py
@@ -33,9 +33,9 @@ def main():
                         help="Output psf FITS file -- default is input_psfcat.fits")
     # allow manual specification of NVSS/SUMSS catalogue (e.g. if running locally...)
     parser.add_argument("--nscat", dest="nscat", type=str,
-                        default="/group/mwasci/$PIPEUSER/GLEAM-X-pipeline/models/NVSS_SUMSS_psfcal.fits",
+                        default="/group/mwasci/$pipeuser/GLEAM-X-pipeline/models/NVSS_SUMSS_psfcal.fits",
                         help="NVSS-SUMSS catalogue filtering extended sources. Default is located at " \
-                             "'/group/mwasci/$PIPEUSER/GLEAM-X-pipeline/models/NVSS_SUMSS_psfcal.fits'")
+                             "'/group/mwasci/$pipeuser/GLEAM-X-pipeline/models/NVSS_SUMSS_psfcal.fits'")
 
     options = parser.parse_args()
 

--- a/bin/radiance.tmpl
+++ b/bin/radiance.tmpl
@@ -7,6 +7,9 @@
 #SBATCH --export=NONE
 #SBATCH --partition=STANDARDQ
 
+pipeuser=PIPEUSER
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+
 module load shifter
 
 function test_fail {

--- a/bin/rescale.tmpl
+++ b/bin/rescale.tmpl
@@ -5,7 +5,8 @@
 #SBATCH --nodes=1
 #SBATCH --array=0-4
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 set -x
 
@@ -40,7 +41,7 @@ do
     fi
 done
 
-python /group/mwasci/${SLURM_JOB_USER}/GLEAM-X-pipeline/bin/polyfit_snapshots.py \
+python /group/mwasci/${pipeuser}/GLEAM-X-pipeline/bin/polyfit_snapshots.py \
                --filelist ${sublist} \
-               --skymodel=/group/mwasci/${SLURM_JOB_USER}/GLEAM-X-pipeline/models/skymodel_only_alpha_sparse_unresolved.fits \
+               --skymodel=/group/mwasci/${pipeuser}/GLEAM-X-pipeline/models/skymodel_only_alpha_sparse_unresolved.fits \
                $readfile $write --rescale --correctall --overwrite --plot

--- a/bin/rfifind.tmpl
+++ b/bin/rfifind.tmpl
@@ -9,6 +9,9 @@
 #SBATCH OUTPUT
 #SBATCH ERROR
 
+pipeuser=PIPEUSER
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+
 function test_fail {
 if [[ $1 != 0 ]]
 then
@@ -78,7 +81,7 @@ then
     echo "Detected that this measurement set has already had its phase centre changed. Not shifting."
 else
     # Determine whether to shift the pointing centre to be more optimally-centred on the peak of the primary beam sensitivity
-    coords=`python /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/calc_pointing.py --metafits=${metafits}`
+    coords=`python /group/mwasci/$PIPEUSER/GLEAM-X-pipeline/bin/calc_pointing.py --metafits=${metafits}`
     echo "Optimally shifting co-ordinates of measurement set to $coords, with zenith shiftback."
     chgcentre ${obsnum}.ms $coords
     # Now shift the pointing centre to point straight up, which approximates minw without making the phase centre rattle around

--- a/bin/self.tmpl
+++ b/bin/self.tmpl
@@ -7,7 +7,9 @@
 #SBATCH --nodes=1
 TASKLINE
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 function test_fail {
 if [[ $1 != 0 ]]
@@ -86,7 +88,7 @@ then
     echo "Detected that this measurement set has already had its phase centre changed. Not shifting."
 else
     # Determine whether to shift the pointing centre to be more optimally-centred on the peak of the primary beam sensitivity
-    coords=`python /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/bin/calc_pointing.py --metafits=${metafits}`
+    coords=`python /group/mwasci/$pipeuser/GLEAM-X-pipeline/bin/calc_pointing.py --metafits=${metafits}`
     echo "Optimally shifting co-ordinates of measurement set to $coords, with zenith shiftback."
     chgcentre ${obsnum}.ms $coords
     # Now shift the pointing centre to point straight up, which approximates minw without making the phase centre rattle around

--- a/bin/uvflag.tmpl
+++ b/bin/uvflag.tmpl
@@ -7,7 +7,9 @@
 #SBATCH --nodes=1
 TASKLINE
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 module load python-casacore
 

--- a/bin/wrap_prep_IDG.tmpl
+++ b/bin/wrap_prep_IDG.tmpl
@@ -11,7 +11,9 @@
 #SBATCH --output=WRAP_OUTPUT
 #SBATCH --error=WRAP_ERROR
 
-source /group/mwasci/$SLURM_JOB_USER/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
+pipeuser=PIPEUSER
+
+source /group/mwasci/$pipeuser/GLEAM-X-pipeline/GLEAM-X-pipeline.profile
 
 output=IDG_OUTPUT
 error=IDG_ERROR


### PR DESCRIPTION
in light of the LDAP and SLURM servers occasionally not setting $USER of
$SLURM_JOB_USER correctly, references to these variables have been
removed from scripts. To replace them `whoami` is used to set up a
temporary `pipeuser` variable that is passed through to the SLURM
template scriptes alongside other expressions.

