### PR TITLE
missing pipeuser and print_function for zeus fix

### DIFF
--- a/bin/obs_manta.sh
+++ b/bin/obs_manta.sh
@@ -21,14 +21,14 @@ computer="zeus"
 account="mwasci"
 standardq="copyq"
 
-PIPEUSER=$(whoami)
+pipeuser=$(whoami)
 
 #initial variables
 
 scratch="/astro"
 group="/group"
-base="$scratch/mwasci/$PIPEUSER/"
-dbdir="$group/mwasci/$PIPEUSER/GLEAM-X-pipeline/"
+base="$scratch/mwasci/$pipeuser/"
+dbdir="$group/mwasci/$pipeuser/GLEAM-X-pipeline/"
 dep=
 queue="-p $standardq"
 tst=
@@ -123,7 +123,8 @@ script="${dbdir}queue/manta_${listbase}.sh"
 
 cat ${dbdir}/bin/manta.tmpl | sed -e "s:OBSLIST:${obslist}:g" \
                                  -e "s:STEM:${stem}:g"  \
-                                 -e "s:BASEDIR:${base}:g"  > ${script}
+                                 -e "s:BASEDIR:${base}:g" \
+                                 -e "s:PIPEUSER:${pipeuser}:g" > ${script}
 #                                 -e "s:ACCOUNT:${account}:g"
 
 output="${dbdir}queue/logs/manta_${listbase}.o%A"

--- a/bin/track_task.py
+++ b/bin/track_task.py
@@ -2,6 +2,7 @@
 
 __author__ = "PaulHancock & Natasha Hurley-Walker"
 
+from __future__ import print_function
 import os
 import sqlite3
 import sys
@@ -50,7 +51,7 @@ def require(args, reqlist):
     """
     for r in reqlist:
         if not getattr(args, r):
-            print "Directive {0} requires argument {1}".format(args.directive, r)
+            print("Directive {0} requires argument {1}".format(args.directive, r))
             sys.exit()
     return True
 
@@ -87,4 +88,4 @@ if __name__ == "__main__":
         require(args, ['jobid', 'taskid', 'finish_time'])
         fail_job(args.jobid, args.taskid, args.finish_time)
     else:
-        print "I don't know what you are asking; please include a queue/start/finish/fail directive"
+        print("I don't know what you are asking; please include a queue/start/finish/fail directive")

--- a/bin/track_task.py
+++ b/bin/track_task.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 __author__ = "PaulHancock & Natasha Hurley-Walker"
 
-from __future__ import print_function
 import os
 import sqlite3
 import sys


### PR DESCRIPTION
had a missing `pipeuser` substitution in the `obs_mantra` script. Also added a `print_function` to `track_task` so zeus does not fall over. 