### PR TITLE
fix to pipeline variable error

### DIFF
--- a/bin/obs_autocal.sh
+++ b/bin/obs_autocal.sh
@@ -15,7 +15,7 @@ echo "obs_autocal.sh [-d dep] [-a account] [-t] obsnum
 exit 1;
 }
 
-pipeline=$(whoami)
+pipeuser=$(whoami)
 
 dep=
 tst=


### PR DESCRIPTION
Typo-ed my way into a problem that needed fixing by not setting a `pipeuser` up, instead setting up `pipeline`. This would cause all a cascading set of errors. 